### PR TITLE
Support tainted resources

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ ACTION_MAPPING['-/+'] = Action.REPLACE;
 ACTION_MAPPING['~'] = Action.UPDATE;
 ACTION_MAPPING['<='] = Action.READ;
 
-const ACTION_LINE_REGEX = /(data\.)?([^.]+)\.([^ ]+)( \(new resource required\))?$/;
+const ACTION_LINE_REGEX = /(data\.)?([^.]+)\.([^ ]+)( \(tainted\))?( \(new resource required\))?$/;
 const ATTRIBUTE_LINE_REGEX = /^ {6}[^ ]/;
 
 /**
@@ -121,7 +121,7 @@ function parseActionLine (offset: number, line: string, action: Action, result: 
     return null;
   }
 
-  const [, dataSourceStr, type, name, newResourceRequiredStr] = match;
+  const [, dataSourceStr, type, name, , newResourceRequiredStr] = match;
   let change;
   change = {
     action: action,

--- a/test/unit/data/11-tainted-resource.expected.json
+++ b/test/unit/data/11-tainted-resource.expected.json
@@ -1,0 +1,21 @@
+{
+  "errors": [],
+  "changedResources": [
+    {
+      "action": "replace",
+      "type": "aws_ecs_task_definition",
+      "name": "sample_app",
+      "changedAttributes": {
+        "id": {
+          "new": {
+            "type": "string",
+            "value": "myservice"
+          },
+          "forcesNewResource": true
+        }
+      },
+      "newResourceRequired": true
+    }
+  ],
+  "changedDataSources": []
+}

--- a/test/unit/data/11-tainted-resource.stdout.txt
+++ b/test/unit/data/11-tainted-resource.stdout.txt
@@ -1,0 +1,7 @@
+
+Terraform will perform the following actions:
+
+-/+ aws_ecs_task_definition.sample_app (tainted) (new resource required)
+      id:                       "myservice" (forces new resource)
+
+Plan: 1 to add, 0 to change, 1 to destroy.

--- a/test/unit/terraform-plan-parser.test.ts
+++ b/test/unit/terraform-plan-parser.test.ts
@@ -66,3 +66,7 @@ test('should handle plan output with Windows line terminator', async (t) => {
 test('should handle sample provided in issue #4', async (t) => {
   return runTest('10-issue-4', t);
 });
+
+test('should handle tainted resources', async (t) => {
+  return runTest('11-tainted-resource', t);
+});


### PR DESCRIPTION
Hey thanks for creating this tool! I've been using it as part of a CI/CD pipeline to verify expected changes in a plan before applying it automatically.

Right now tainted resources result in parsing errors, I believe this PR is all that's needed to fix this.