### PR TITLE
Add support for modules parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The output is an object with these top-level properties:
 Each _changed resource_ has the following properties:
 
 - **`action`:** One of `"create"`, `"destroy"`, `"replace"`, `"update"`
+- **`module`:** Name of a module that contains a resource (only present when module is not `root`)
 - **`type`:** Type of resource (e.g. `"aws_ecs_service"`)
 - **`name`:** Resource name (e.g. `"my_service"`)
 - **`changedAttributes`:** An object whose keys are an attribute name and value is an object

--- a/test/unit/data/12-modules.expected.json
+++ b/test/unit/data/12-modules.expected.json
@@ -1,0 +1,80 @@
+{
+  "errors": [],
+  "changedResources": [
+    {
+      "action": "create",
+      "type": "null_resource",
+      "name": "test0",
+      "changedAttributes": {
+        "id": {
+          "new": {
+            "type": "computed"
+          }
+        },
+        "triggers.%": {
+          "new": {
+            "type": "string",
+            "value": "1"
+          }
+        },
+        "triggers.trigger": {
+          "new": {
+            "type": "string",
+            "value": "test0"
+          }
+        }
+      }
+    },
+    {
+      "action": "create",
+      "module": "test1",
+      "type": "null_resource",
+      "name": "test1",
+      "changedAttributes": {
+        "id": {
+          "new": {
+            "type": "computed"
+          }
+        },
+        "triggers.%": {
+          "new": {
+            "type": "string",
+            "value": "1"
+          }
+        },
+        "triggers.trigger": {
+          "new": {
+            "type": "string",
+            "value": "test1"
+          }
+        }
+      }
+    },
+    {
+      "action": "create",
+      "module": "test2",
+      "type": "null_resource",
+      "name": "test2",
+      "changedAttributes": {
+        "id": {
+          "new": {
+            "type": "computed"
+          }
+        },
+        "triggers.%": {
+          "new": {
+            "type": "string",
+            "value": "1"
+          }
+        },
+        "triggers.trigger": {
+          "new": {
+            "type": "string",
+            "value": "test2"
+          }
+        }
+      }
+    }
+  ],
+  "changedDataSources": []
+}

--- a/test/unit/data/12-modules.stdout.txt
+++ b/test/unit/data/12-modules.stdout.txt
@@ -1,0 +1,36 @@
+Refreshing Terraform state in-memory prior to plan...
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+
+
+------------------------------------------------------------------------
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  + null_resource.test0
+      id:               <computed>
+      triggers.%:       "1"
+      triggers.trigger: "test0"
+
+  + module.test1.null_resource.test1
+      id:               <computed>
+      triggers.%:       "1"
+      triggers.trigger: "test1"
+
+  + module.test1.module.test2.null_resource.test2
+      id:               <computed>
+      triggers.%:       "1"
+      triggers.trigger: "test2"
+
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+
+------------------------------------------------------------------------
+
+Note: You didn't specify an "-out" parameter to save this plan, so Terraform
+can't guarantee that exactly these actions will be performed if
+"terraform apply" is subsequently run.

--- a/test/unit/terraform-plan-parser.test.ts
+++ b/test/unit/terraform-plan-parser.test.ts
@@ -70,3 +70,7 @@ test('should handle sample provided in issue #4', async (t) => {
 test('should handle tainted resources', async (t) => {
   return runTest('11-tainted-resource', t);
 });
+
+test('should handle modules', async (t) => {
+  return runTest('12-modules', t);
+});


### PR DESCRIPTION
Fixes #6 

This one will add `module` parameter only to resources that were created inside a module.