### PR TITLE
 Expose full path to resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ The output is an object with these top-level properties:
 Each _changed resource_ has the following properties:
 
 - **`action`:** One of `"create"`, `"destroy"`, `"replace"`, `"update"`
-- **`module`:** Name of a module that contains a resource (only present when module is not `root`)
 - **`type`:** Type of resource (e.g. `"aws_ecs_service"`)
 - **`name`:** Resource name (e.g. `"my_service"`)
+- **`path`:** Full path to resource as printed in plan output (e.g. `"module.module1.module.module2.aws_ecs_service.my_service"`)
 - **`module`:** Fully qualified module name (e.g. `"module1.module2"`) or `undefined` if resource not within module.
 - **`changedAttributes`:** An object whose keys are an attribute name and value is an object
 - **`newResourceRequired`:** A flag to indicate if a new resource is required (only present if `true`)
@@ -143,6 +143,7 @@ Each _data source_ has the following properties:
 - **`action`:** The action will always be `"read"`
 - **`type`:** Type of resource (e.g. `"external"`)
 - **`name`:** Data source name (e.g. `"ecr_image_digests"`)
+- **`path`:** Full path to data source as printed in plan output (e.g. `"module.module1.module.module2.data.external.ecr_image_digests"`)
 - **`module`:** Fully qualified module name (e.g. `"module1.module2"`) or `undefined` if data source not within module.
 - **`changedAttributes`:** An object whose keys are an attribute name and value is an object
 
@@ -156,6 +157,7 @@ Each _data source_ has the following properties:
       "action": "update",
       "type": "aws_ecs_service",
       "name": "sample_app",
+      "path": "aws_ecs_service.sample_app",
       "changedAttributes": {
         "task_definition": {
           "old": {
@@ -175,6 +177,7 @@ Each _data source_ has the following properties:
       "action": "read",
       "type": "external",
       "name": "ecr_image_digests",
+      "path": "data.external.ecr_image_digests",
       "changedAttributes": {
         "id": {
           "new": {

--- a/test/unit/data/00-terraform-plan.expected.json
+++ b/test/unit/data/00-terraform-plan.expected.json
@@ -5,6 +5,7 @@
       "action": "update",
       "type": "aws_ecs_service",
       "name": "sample_app",
+      "path": "aws_ecs_service.sample_app",
       "changedAttributes": {
         "task_definition": {
           "old": {
@@ -22,6 +23,7 @@
       "action": "replace",
       "type": "aws_ecs_task_definition",
       "name": "sample_app",
+      "path": "aws_ecs_task_definition.sample_app",
       "changedAttributes": {
         "id": {
           "old": {
@@ -98,6 +100,7 @@
       "action": "replace",
       "type": "null_resource",
       "name": "promote_images",
+      "path": "null_resource.promote_images",
       "changedAttributes": {
         "id": {
           "old": {
@@ -139,6 +142,7 @@
       "action": "read",
       "type": "external",
       "name": "ecr_image_digests",
+      "path": "data.external.ecr_image_digests",
       "changedAttributes": {
         "id": {
           "new": {

--- a/test/unit/data/01-terraform-plan.expected.json
+++ b/test/unit/data/01-terraform-plan.expected.json
@@ -5,6 +5,7 @@
       "action": "update",
       "type": "aws_ecs_service",
       "name": "sample_app",
+      "path": "aws_ecs_service.sample_app",
       "changedAttributes": {
         "task_definition": {
           "old": {
@@ -22,6 +23,7 @@
       "action": "replace",
       "type": "aws_ecs_task_definition",
       "name": "sample_app",
+      "path": "aws_ecs_task_definition.sample_app",
       "changedAttributes": {
         "id": {
           "old": {
@@ -98,6 +100,7 @@
       "action": "replace",
       "type": "null_resource",
       "name": "promote_images",
+      "path": "null_resource.promote_images",
       "changedAttributes": {
         "id": {
           "old": {
@@ -139,6 +142,7 @@
       "action": "read",
       "type": "external",
       "name": "ecr_image_digests",
+      "path": "data.external.ecr_image_digests",
       "changedAttributes": {
         "id": {
           "new": {

--- a/test/unit/data/02-terraform-plan.expected.json
+++ b/test/unit/data/02-terraform-plan.expected.json
@@ -22,6 +22,7 @@
       "action": "update",
       "type": "aws_ecs_service",
       "name": "sample_app",
+      "path": "aws_ecs_service.sample_app",
       "changedAttributes": {
         "unterminated_string": {
           "new": {
@@ -53,6 +54,7 @@
       "action": "replace",
       "type": "aws_ecs_task_definition",
       "name": "sample_app",
+      "path": "aws_ecs_task_definition.sample_app",
       "changedAttributes": {
         "id": {
           "new": {
@@ -70,6 +72,7 @@
       "action": "read",
       "type": "external",
       "name": "ecr_image_digests",
+      "path": "data.external.ecr_image_digests",
       "changedAttributes": {
         "attribute-with-no-value": {}
       }

--- a/test/unit/data/03-terraform-plan.expected.json
+++ b/test/unit/data/03-terraform-plan.expected.json
@@ -10,24 +10,28 @@
       "action": "create",
       "type": "aws_ecs_service",
       "name": "this_is_created",
+      "path": "aws_ecs_service.this_is_created",
       "changedAttributes": {}
     },
     {
       "action": "destroy",
       "type": "aws_ecs_service",
       "name": "this_is_destroyed",
+      "path": "aws_ecs_service.this_is_destroyed",
       "changedAttributes": {}
     },
     {
       "action": "replace",
       "type": "aws_ecs_service",
       "name": "this_is_replaced",
+      "path": "aws_ecs_service.this_is_replaced",
       "changedAttributes": {}
     },
     {
       "action": "update",
       "type": "aws_ecs_service",
       "name": "this_is_updated",
+      "path": "aws_ecs_service.this_is_updated",
       "changedAttributes": {}
     }
   ],
@@ -36,6 +40,7 @@
       "action": "read",
       "type": "external",
       "name": "this_is_a_read",
+      "path": "data.external.this_is_a_read",
       "changedAttributes": {}
     }
   ]

--- a/test/unit/data/06-attribute-value-unexpected-delimiter.expected.json
+++ b/test/unit/data/06-attribute-value-unexpected-delimiter.expected.json
@@ -5,6 +5,7 @@
       "action": "update",
       "type": "aws_ecs_service",
       "name": "sample_app",
+      "path": "aws_ecs_service.sample_app",
       "changedAttributes": {
         "task_definition": {
           "new": {

--- a/test/unit/data/08-no-attribute-name.expected.json
+++ b/test/unit/data/08-no-attribute-name.expected.json
@@ -10,6 +10,7 @@
       "action": "update",
       "type": "aws_ecs_service",
       "name": "blah",
+      "path": "aws_ecs_service.blah",
       "changedAttributes": {}
     }
   ],

--- a/test/unit/data/09-terraform-plan-windows-line-end.expected.json
+++ b/test/unit/data/09-terraform-plan-windows-line-end.expected.json
@@ -5,6 +5,7 @@
       "action": "update",
       "type": "aws_ecs_service",
       "name": "sample_app",
+      "path": "aws_ecs_service.sample_app",
       "changedAttributes": {
         "task_definition": {
           "old": {
@@ -22,6 +23,7 @@
       "action": "replace",
       "type": "aws_ecs_task_definition",
       "name": "sample_app",
+      "path": "aws_ecs_task_definition.sample_app",
       "changedAttributes": {
         "id": {
           "old": {
@@ -98,6 +100,7 @@
       "action": "replace",
       "type": "null_resource",
       "name": "promote_images",
+      "path": "null_resource.promote_images",
       "changedAttributes": {
         "id": {
           "old": {
@@ -139,6 +142,7 @@
       "action": "read",
       "type": "external",
       "name": "ecr_image_digests",
+      "path": "data.external.ecr_image_digests",
       "changedAttributes": {
         "id": {
           "new": {

--- a/test/unit/data/10-issue-4.expected.json
+++ b/test/unit/data/10-issue-4.expected.json
@@ -5,6 +5,7 @@
       "action": "create",
       "type": "aws_iam_role",
       "name": "terraform_demo",
+      "path": "aws_iam_role.terraform_demo",
       "changedAttributes": {
         "id": {
           "new": {

--- a/test/unit/data/11-tainted-resource.expected.json
+++ b/test/unit/data/11-tainted-resource.expected.json
@@ -5,6 +5,7 @@
       "action": "replace",
       "type": "aws_ecs_task_definition",
       "name": "sample_app",
+      "path": "aws_ecs_task_definition.sample_app",
       "tainted": true,
       "changedAttributes": {
         "id": {

--- a/test/unit/data/12-modules.expected.json
+++ b/test/unit/data/12-modules.expected.json
@@ -5,6 +5,7 @@
       "action": "create",
       "type": "null_resource",
       "name": "test0",
+      "path": "null_resource.test0",
       "changedAttributes": {
         "id": {
           "new": {
@@ -30,6 +31,7 @@
       "module": "test1",
       "type": "null_resource",
       "name": "test1",
+      "path": "module.test1.null_resource.test1",
       "changedAttributes": {
         "id": {
           "new": {
@@ -55,6 +57,7 @@
       "module": "test1.test2",
       "type": "null_resource",
       "name": "test2",
+      "path": "module.test1.module.test2.null_resource.test2",
       "changedAttributes": {
         "id": {
           "new": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,86 @@
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
+"@babel/code-frame@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz#bd71d9b192af978df915829d39d4094456439a0c"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.51"
+
+"@babel/generator@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz#6c7575ffde761d07485e04baedc0392c6d9e30f6"
+  dependencies:
+    "@babel/types" "7.0.0-beta.51"
+    jsesc "^2.5.1"
+    lodash "^4.17.5"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-function-name@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz#21b4874a227cf99ecafcc30a90302da5a2640561"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.51"
+    "@babel/template" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+
+"@babel/helper-get-function-arity@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz#3281b2d045af95c172ce91b20825d85ea4676411"
+  dependencies:
+    "@babel/types" "7.0.0-beta.51"
+
+"@babel/helper-split-export-declaration@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz#8a6c3f66c4d265352fc077484f9f6e80a51ab978"
+  dependencies:
+    "@babel/types" "7.0.0-beta.51"
+
+"@babel/highlight@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz#e8844ae25a1595ccfd42b89623b4376ca06d225d"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/parser@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz#27cec2df409df60af58270ed8f6aa55409ea86f6"
+
+"@babel/template@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz#9602a40aebcf357ae9677e2532ef5fc810f5fbff"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+    lodash "^4.17.5"
+
+"@babel/traverse@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz#981daf2cec347a6231d3aa1d9e1803b03aaaa4a8"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.51"
+    "@babel/generator" "7.0.0-beta.51"
+    "@babel/helper-function-name" "7.0.0-beta.51"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    invariant "^2.2.0"
+    lodash "^4.17.5"
+
+"@babel/types@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz#d802b7b543b5836c778aa691797abf00f3d97ea9"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.5"
+    to-fast-properties "^2.0.0"
+
 "@concordance/react@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@concordance/react/-/react-1.0.0.tgz#fcf3cad020e5121bfd1c61d05bc3516aac25f734"
@@ -841,7 +921,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -1123,6 +1203,12 @@ debug@^3.0.1, debug@^3.1.0:
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+decamelize@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz#656d7bbc8094c4c788ea53c5840908c9c7d063c7"
+  dependencies:
+    xregexp "4.0.0"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -1423,6 +1509,12 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  dependencies:
+    locate-path "^3.0.0"
+
 fn-name@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
@@ -1556,6 +1648,10 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
+globals@^11.1.0:
+  version "11.7.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
+
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -1590,9 +1686,9 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-handlebars@^4.0.3:
+handlebars@^4.0.11:
   version "4.0.11"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"
@@ -1762,7 +1858,7 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -2035,13 +2131,17 @@ istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
 
+istanbul-lib-coverage@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#2aee0e073ad8c5f6a0b00e0dfbf52b4667472eda"
+
 istanbul-lib-hook@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.10.0, istanbul-lib-instrument@^1.10.1:
+istanbul-lib-instrument@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
   dependencies:
@@ -2053,6 +2153,18 @@ istanbul-lib-instrument@^1.10.0, istanbul-lib-instrument@^1.10.1:
     istanbul-lib-coverage "^1.2.0"
     semver "^5.3.0"
 
+istanbul-lib-instrument@^2.1.0:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz#b287cbae2b5f65f3567b05e2e29b275eaf92d25e"
+  dependencies:
+    "@babel/generator" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/template" "7.0.0-beta.51"
+    "@babel/traverse" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+    istanbul-lib-coverage "^2.0.1"
+    semver "^5.5.0"
+
 istanbul-lib-report@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz#2df12188c0fa77990c0d2176d2d0ba3394188259"
@@ -2062,21 +2174,21 @@ istanbul-lib-report@^1.1.3:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
+istanbul-lib-source-maps@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
   dependencies:
     debug "^3.1.0"
-    istanbul-lib-coverage "^1.1.2"
+    istanbul-lib-coverage "^1.2.0"
     mkdirp "^0.5.1"
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.4.0.tgz#3d7b44b912ecbe7652a603662b962120739646a1"
+istanbul-reports@^1.4.1:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.0.tgz#c6c2867fa65f59eb7dcedb7f845dfc76aaee70f9"
   dependencies:
-    handlebars "^4.0.3"
+    handlebars "^4.0.11"
 
 js-string-escape@^1.0.1:
   version "1.0.1"
@@ -2100,6 +2212,10 @@ jsbn@~0.1.0:
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
+
+jsesc@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -2215,6 +2331,13 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -2247,7 +2370,7 @@ lodash.merge@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
-lodash@^4.17.4:
+lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -2571,9 +2694,9 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nyc@^11.4.1:
-  version "11.8.0"
-  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.8.0.tgz#1e8453b0644f8fea4d829b1a6636663157cd3b00"
+nyc@^12.0.1:
+  version "12.0.2"
+  resolved "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz#8a4a4ed690966c11ec587ff87eea0c12c974ba99"
   dependencies:
     archy "^1.0.0"
     arrify "^1.0.1"
@@ -2585,12 +2708,12 @@ nyc@^11.4.1:
     find-up "^2.1.0"
     foreground-child "^1.5.3"
     glob "^7.0.6"
-    istanbul-lib-coverage "^1.1.2"
+    istanbul-lib-coverage "^1.2.0"
     istanbul-lib-hook "^1.1.0"
-    istanbul-lib-instrument "^1.10.0"
+    istanbul-lib-instrument "^2.1.0"
     istanbul-lib-report "^1.1.3"
-    istanbul-lib-source-maps "^1.2.3"
-    istanbul-reports "^1.4.0"
+    istanbul-lib-source-maps "^1.2.5"
+    istanbul-reports "^1.4.1"
     md5-hex "^1.2.0"
     merge-source-map "^1.1.0"
     micromatch "^3.1.10"
@@ -2709,15 +2832,31 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  dependencies:
+    p-limit "^2.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 package-hash@^1.2.0:
   version "1.2.0"
@@ -3196,7 +3335,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -3552,6 +3691,10 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
@@ -3860,6 +4003,10 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
+xregexp@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
+
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
@@ -3868,6 +4015,10 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
+"y18n@^3.2.1 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -3875,6 +4026,12 @@ yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
+yargs-parser@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^8.0.0:
   version "8.1.0"
@@ -3905,13 +4062,13 @@ yargs@11.1.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+yargs@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz#6432e56123bb4e7c3562115401e98374060261c2"
   dependencies:
     cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
+    decamelize "^2.0.0"
+    find-up "^3.0.0"
     get-caller-file "^1.0.1"
     os-locale "^2.0.0"
     require-directory "^2.1.1"
@@ -3919,8 +4076,8 @@ yargs@^11.0.0:
     set-blocking "^2.0.0"
     string-width "^2.0.0"
     which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^10.1.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
E.g.

```
{
...
      "module": "test1.test2",
      "type": "null_resource",
      "name": "test2",
      "path": "module.test1.module.test2.null_resource.test2",
...
}
```

Exposing the `path` is very convenient for consumers and it's already in memory/computed anyway. It avoids having to try and rebuild the path based on the module, name, (data) type, etc.