### PR TITLE
Ignore unchanged attributes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -340,6 +340,10 @@ function parseAttributeLine (line: string, lastChange: Changed, errors: Array<Pa
     result.new = newObj;
   }
 
+  if (result.old && result.old.value === result.new.value) {
+    return;
+  }
+
   if (forcesNewResource) {
     result.forcesNewResource = true;
   }

--- a/test/unit/data/00-terraform-plan.expected.json
+++ b/test/unit/data/00-terraform-plan.expected.json
@@ -55,16 +55,6 @@
           },
           "forcesNewResource": true
         },
-        "family": {
-          "old": {
-            "type": "string",
-            "value": "sample-app"
-          },
-          "new": {
-            "type": "string",
-            "value": "sample-app"
-          }
-        },
         "network_mode": {
           "old": {
             "type": "string",
@@ -81,16 +71,6 @@
           },
           "new": {
             "type": "computed"
-          }
-        },
-        "task_role_arn": {
-          "old": {
-            "type": "string",
-            "value": "arn:aws:iam::123123123123:role/SampleApp"
-          },
-          "new": {
-            "type": "string",
-            "value": "arn:aws:iam::123123123123:role/SampleApp"
           }
         }
       },
@@ -111,16 +91,6 @@
             "type": "computed"
           },
           "forcesNewResource": true
-        },
-        "triggers.%": {
-          "old": {
-            "type": "string",
-            "value": "1"
-          },
-          "new": {
-            "type": "string",
-            "value": "1"
-          }
         },
         "triggers.deploy_job_hash": {
           "old": {

--- a/test/unit/data/01-terraform-plan.expected.json
+++ b/test/unit/data/01-terraform-plan.expected.json
@@ -55,16 +55,6 @@
           },
           "forcesNewResource": true
         },
-        "family": {
-          "old": {
-            "type": "string",
-            "value": "sample-app"
-          },
-          "new": {
-            "type": "string",
-            "value": "sample-app"
-          }
-        },
         "network_mode": {
           "old": {
             "type": "string",
@@ -81,16 +71,6 @@
           },
           "new": {
             "type": "computed"
-          }
-        },
-        "task_role_arn": {
-          "old": {
-            "type": "string",
-            "value": "arn:aws:iam::123123123123:role/SampleApp"
-          },
-          "new": {
-            "type": "string",
-            "value": "arn:aws:iam::123123123123:role/SampleApp"
           }
         }
       },
@@ -111,16 +91,6 @@
             "type": "computed"
           },
           "forcesNewResource": true
-        },
-        "triggers.%": {
-          "old": {
-            "type": "string",
-            "value": "1"
-          },
-          "new": {
-            "type": "string",
-            "value": "1"
-          }
         },
         "triggers.deploy_job_hash": {
           "old": {

--- a/test/unit/data/09-terraform-plan-windows-line-end.expected.json
+++ b/test/unit/data/09-terraform-plan-windows-line-end.expected.json
@@ -55,16 +55,6 @@
           },
           "forcesNewResource": true
         },
-        "family": {
-          "old": {
-            "type": "string",
-            "value": "sample-app"
-          },
-          "new": {
-            "type": "string",
-            "value": "sample-app"
-          }
-        },
         "network_mode": {
           "old": {
             "type": "string",
@@ -81,16 +71,6 @@
           },
           "new": {
             "type": "computed"
-          }
-        },
-        "task_role_arn": {
-          "old": {
-            "type": "string",
-            "value": "arn:aws:iam::123123123123:role/SampleApp"
-          },
-          "new": {
-            "type": "string",
-            "value": "arn:aws:iam::123123123123:role/SampleApp"
           }
         }
       },
@@ -111,16 +91,6 @@
             "type": "computed"
           },
           "forcesNewResource": true
-        },
-        "triggers.%": {
-          "old": {
-            "type": "string",
-            "value": "1"
-          },
-          "new": {
-            "type": "string",
-            "value": "1"
-          }
         },
         "triggers.deploy_job_hash": {
           "old": {

--- a/test/unit/data/14-ignore-unchanged-attributes.expected.json
+++ b/test/unit/data/14-ignore-unchanged-attributes.expected.json
@@ -1,0 +1,25 @@
+{
+    "errors": [],
+    "changedResources": [
+      {
+        "action": "update",
+        "type": "aws_ecs_service",
+        "name": "sample_app",
+        "path": "aws_ecs_service.sample_app",
+        "changedAttributes": {
+          "setting.changed": {
+            "old": {
+              "type": "string",
+              "value": "A"
+            },
+            "new": {
+              "type": "string",
+              "value": "B"
+            }
+          }
+        }
+      }
+    ],
+    "changedDataSources": []
+  }
+  

--- a/test/unit/data/14-ignore-unchanged-attributes.stdout.txt
+++ b/test/unit/data/14-ignore-unchanged-attributes.stdout.txt
@@ -1,0 +1,30 @@
+Refreshing Terraform state in-memory prior to plan...
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+
+aws_ecs_service.sample_app: Refreshing state... (ID: arn:aws:ecs:us-east-1:123123123123:service/sample-app)
+
+------------------------------------------------------------------------
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  ~ update in-place
+-/+ destroy and then create replacement
+ <= read (data resources)
+
+Terraform will perform the following actions:
+
+  ~ aws_ecs_service.sample_app
+      setting.unchanged: "A" => "A"
+      setting.changed:   "A" => "B"
+
+
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+------------------------------------------------------------------------
+
+This plan was saved to: terraform.plan
+
+To perform exactly these actions, run the following command to apply:
+    terraform apply "terraform.plan"

--- a/test/unit/terraform-plan-parser.test.ts
+++ b/test/unit/terraform-plan-parser.test.ts
@@ -78,3 +78,7 @@ test('should handle modules', async (t) => {
 test('should handle no changes', async (t) => {
   return runTest('13-no-changes', t);
 });
+
+test('should ignore unchanged attributes', async (t) => {
+  return runTest('14-ignore-unchanged-attributes', t);
+});


### PR DESCRIPTION
This fixes #20. Ignoring unchanged attributes makes the output much more readable since plans for certain AWS resources are full of them. It's going to be fixed upstream in an upcoming release https://github.com/hashicorp/terraform/issues/15180#issuecomment-435241641 so no problems if you'd rather wait for v0.12.0